### PR TITLE
Fix double Content-Length header being sent.

### DIFF
--- a/esp8266_deauther/data.h
+++ b/esp8266_deauther/data.h
@@ -58,7 +58,7 @@ void sendToBuffer(String str) {
 }
 
 void sendHeader(int code, String type, size_t _size) {
-  server.sendHeader("Content-Length", (String)_size);
+  server.setContentLength(_size);  
   server.send(code, type, "");
 }
 

--- a/esp8266_deauther/data.h
+++ b/esp8266_deauther/data.h
@@ -58,7 +58,7 @@ void sendToBuffer(String str) {
 }
 
 void sendHeader(int code, String type, size_t _size) {
-  server.setContentLength(_size);  
+  server.setContentLength(_size);
   server.send(code, type, "");
 }
 


### PR DESCRIPTION
This sends the correct header ```server.sendHeader("Content-Length", (String)_size);```.
But after, when calling ```server.send(code, type, "");``` a zeroed Content-Length was sent again by 'ESP8266WebServer::_prepareHeader'.

Just telling the server the current Content-Length is more efficient and fixes the problem.