### PR TITLE
Add Cache-control headers to Javascript & CSS

### DIFF
--- a/esp8266_deauther/data.h
+++ b/esp8266_deauther/data.h
@@ -63,7 +63,7 @@ void sendHeader(int code, String type, size_t _size) {
 }
 
 void sendFile(int code, String type, const char* adr, size_t len) {
-  if (type != "text/json") server.sendHeader("Cache-Control", "max-age=400");
+  server.sendHeader("Cache-Control", "max-age=400");
   sendHeader(code,type,len);
   /*
   int runs = len/bufSize;

--- a/esp8266_deauther/data.h
+++ b/esp8266_deauther/data.h
@@ -63,6 +63,7 @@ void sendHeader(int code, String type, size_t _size) {
 }
 
 void sendFile(int code, String type, const char* adr, size_t len) {
+  if (type != "text/json") server.sendHeader("Cache-Control", "max-age=400");
   sendHeader(code,type,len);
   /*
   int runs = len/bufSize;

--- a/esp8266_deauther/esp8266_deauther.ino
+++ b/esp8266_deauther/esp8266_deauther.ino
@@ -171,34 +171,27 @@ void loadInfoHTML(){
   sendFile(200, "text/html", data_infoHTML, sizeof(data_infoHTML));
 }
 void loadLicense(){
-  server.sendHeader("Cache-Control", "max-age=1000");
   sendFile(200, "text/plain", data_license, sizeof(data_license));
 }
 
 void loadFunctionsJS() {
-  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_functionsJS, sizeof(data_js_functionsJS));
 }
 void loadAPScanJS() {
-  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_apscanJS, sizeof(data_js_apscanJS));
 }
 void loadStationsJS() {
-  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_stationsJS, sizeof(data_js_stationsJS));
 }
 void loadAttackJS() {
   attack.ssidChange = true;
-  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_attackJS, sizeof(data_js_attackJS));
 }
 void loadSettingsJS() {
-  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_settingsJS, sizeof(data_js_settingsJS));
 }
 
 void loadStyle() {
-  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/css;charset=UTF-8", data_styleCSS, sizeof(data_styleCSS));
 }
 

--- a/esp8266_deauther/esp8266_deauther.ino
+++ b/esp8266_deauther/esp8266_deauther.ino
@@ -171,27 +171,34 @@ void loadInfoHTML(){
   sendFile(200, "text/html", data_infoHTML, sizeof(data_infoHTML));
 }
 void loadLicense(){
+  server.sendHeader("Cache-Control", "max-age=1000");
   sendFile(200, "text/plain", data_license, sizeof(data_license));
 }
 
 void loadFunctionsJS() {
+  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_functionsJS, sizeof(data_js_functionsJS));
 }
 void loadAPScanJS() {
+  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_apscanJS, sizeof(data_js_apscanJS));
 }
 void loadStationsJS() {
+  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_stationsJS, sizeof(data_js_stationsJS));
 }
 void loadAttackJS() {
   attack.ssidChange = true;
+  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_attackJS, sizeof(data_js_attackJS));
 }
 void loadSettingsJS() {
+  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/javascript", data_js_settingsJS, sizeof(data_js_settingsJS));
 }
 
 void loadStyle() {
+  server.sendHeader("Cache-Control", "max-age=300");
   sendFile(200, "text/css;charset=UTF-8", data_styleCSS, sizeof(data_styleCSS));
 }
 


### PR DESCRIPTION
Every time a page is (re)loaded, the ESP8266 has to send the stylesheet and javascript files each time a page loads. Although this is minimal (20-50ms in devtools Networks pane), it can improve page load speeds when the client device is spamming network connectivity check requests.

Adding the `Cache-Control` headers makes the browser store these files in memory (for 300 seconds, could be increased). The same could be done for the HTML files, but that would allow the pages to *ghost-load* even when not connected to the ESP8266.