### PR TITLE
Bootloop patch

### DIFF
--- a/esp8266_deauther/CLI.cpp
+++ b/esp8266_deauther/CLI.cpp
@@ -13,7 +13,7 @@ CLI::CLI() {
 CLI::~CLI() {}
 
 void CLI::load() {
-    String defaultValue = String(CLI_DEFAULT_AUTOSTART);
+    String defaultValue = str(CLI_DEFAULT_AUTOSTART);
     checkFile(execPath, defaultValue);
     execFile(execPath);
 }

--- a/esp8266_deauther/DisplayUI.cpp
+++ b/esp8266_deauther/DisplayUI.cpp
@@ -734,13 +734,13 @@ void DisplayUI::drawLoadingScan() {
     if (scan.isScanning()) {
         percentage = String(scan.getPercentage()) + '%';
     } else {
-        percentage = String(DSP_SCAN_DONE);
+        percentage = str(DSP_SCAN_DONE);
     }
 
-    drawString(0, leftRight(String(DSP_SCAN_FOR), scan.getMode(), maxLen));
-    drawString(1, leftRight(String(DSP_APS), String(accesspoints.count()), maxLen));
-    drawString(2, leftRight(String(DSP_STS), String(stations.count()), maxLen));
-    drawString(3, leftRight(String(DSP_PKTS), String(scan.getPacketRate()) + String(DSP_S), maxLen));
+    drawString(0, leftRight(str(DSP_SCAN_FOR), scan.getMode(), maxLen));
+    drawString(1, leftRight(str(DSP_APS), String(accesspoints.count()), maxLen));
+    drawString(2, leftRight(str(DSP_STS), String(stations.count()), maxLen));
+    drawString(3, leftRight(str(DSP_PKTS), String(scan.getPacketRate()) + str(DSP_S), maxLen));
     drawString(4, center(percentage, maxLen));
 }
 
@@ -772,10 +772,10 @@ void DisplayUI::drawPacketMonitor() {
 }
 
 void DisplayUI::drawIntro() {
-    drawString(0, center(String(D_INTRO_0), maxLen));
-    drawString(1, center(String(D_INTRO_1), maxLen));
-    drawString(2, center(String(D_INTRO_2), maxLen));
-    drawString(3, center(String(D_INTRO_3), maxLen));
+    drawString(0, center(str(D_INTRO_0), maxLen));
+    drawString(1, center(str(D_INTRO_1), maxLen));
+    drawString(2, center(str(D_INTRO_2), maxLen));
+    drawString(3, center(str(D_INTRO_3), maxLen));
     drawString(4, center(settings.getVersion(), maxLen));
 }
 

--- a/esp8266_deauther/Scan.cpp
+++ b/esp8266_deauther/Scan.cpp
@@ -411,19 +411,19 @@ uint32_t Scan::getPackets(int i) {
 String Scan::getMode() {
     switch (scanMode) {
     case SCAN_MODE_OFF:
-        return String(SC_MODE_OFF);
+        return str(SC_MODE_OFF);
 
     case SCAN_MODE_APS:
-        return String(SC_MODE_AP);
+        return str(SC_MODE_AP);
 
     case SCAN_MODE_STATIONS:
-        return String(SC_MODE_ST);
+        return str(SC_MODE_ST);
 
     case SCAN_MODE_ALL:
-        return String(SC_MODE_ALL);
+        return str(SC_MODE_ALL);
 
     case SCAN_MODE_SNIFFER:
-        return String(SC_MODE_SNIFFER);
+        return str(SC_MODE_SNIFFER);
 
     default:
         return String();


### PR DESCRIPTION
Changed few lines from: String(SOME_PROGMEM_VAR)
Into: str(SOME_PROGMEM_VAR)

I practically checked the CLI.cpp and DisplayUI.cpp occurences but didn't test Scan.cpp ones. 
(I just assumed that the same principle applies since the variables that were modified in this commit were defined the same way as the ones in CLI/DisplayUI)

If anyone would like to verify or apply similar changes then here's python code that was used
```python
import re, os
files_containing_progmem_strings = ['language.h', 'wifi.h', 'webfiles.h', 'DisplayUI.h', 'oui.h'] # grep PROGMEM ./* -i | less
pgm_strings = []
for fname in files_containing_progmem_strings:
    pgm_strings += re.findall(r'(\w+)\[\]', open(fname).read())

print('List of all progmem strings that were found')
for pgm in pgm_strings:
    print(pgm)

print('\n\n\n\n\n\nList of files that will be searched (and modified if any progmem string is found)')
for fname in [f for f in os.listdir('.') if os.path.isfile(f) and (f.endswith('.cpp') or f.endswith('.h') or f.endswith('.ino'))]:
    print(fname)
    with open(fname, 'rb') as f:
        text = f.read().decode('utf8')

    with open(fname,"wb+") as f:
        for pgm in pgm_strings:
            text = re.sub(re.compile('String\('+pgm), 'str('+pgm, text)
        f.write(text.encode())
```