### PR TITLE
Fix for setting web AP channel 

### DIFF
--- a/esp8266_deauther/esp8266_deauther.ino
+++ b/esp8266_deauther/esp8266_deauther.ino
@@ -125,9 +125,6 @@ void setup() {
     // create scan.json
     scan.setup();
 
-    // set channel
-    setWifiChannel(settings::getWifiSettings().channel, true);
-
     // dis/enable serial command interface
     if (settings::getCLISettings().enabled) {
         cli.enable();

--- a/esp8266_deauther/wifi.cpp
+++ b/esp8266_deauther/wifi.cpp
@@ -192,7 +192,7 @@ namespace wifi {
         setPath("/web");
         setSSID(settings::getAccessPointSettings().ssid);
         setPassword(settings::getAccessPointSettings().password);
-        setChannel(1);
+        setChannel(settings::getWifiSettings().channel);
         setHidden(settings::getAccessPointSettings().hidden);
         setCaptivePortal(settings::getWebSettings().captive_portal);
 


### PR DESCRIPTION
**Describe the bug**
After downloading and trying out this project I discovered that no matter what AP channel I chose in the settings in the web interface the AP would always start in channel 1. This seems to be related to most probably deprecated and left over code for changing the AP channel.

**To Reproduce**
Steps to reproduce the behavior:

1. Compile the project and load it onto your device
2. Connect to web interface via wifi
3. Go to settings and set the AP channel to something different than the default channel 1
4. Save and reload settings to confirm successful save
5. Reboot and check wifi channel of connected client (e.g. with iwconfig)
6. Actual channel is still 1 no matter the settings

**Expected behavior**
Changing the wifi channel in settings should lead to the AP actually switching to the new channel after reboot

**Environment:**
- Version: 2.6.0
- Hardware: Wemos D1 Mini Pro

**Fix**
This behaviour is fixed with this pull request.