### PR TITLE
Fix setChannel range check

### DIFF
--- a/esp8266_deauther/wifi.cpp
+++ b/esp8266_deauther/wifi.cpp
@@ -85,7 +85,7 @@ namespace wifi {
     }
 
     void setChannel(uint8_t ch) {
-        if ((ch < 1) && (ch > 14)) {
+        if ((ch < 1) || (ch > 14)) {
             debuglnF("ERROR: Channel must be withing the range of 1-14");
         } else {
             ap_settings.channel = ch;


### PR DESCRIPTION
`(ch < 1) && (ch > 14)`

Channel can not be below 1 AND above 14 - this should be an OR.

Note that i am currently unable to test these changes locally in case anything depends on this buggy check, but that seems unlikely?