### PR TITLE
Fixed ap.cpp password field in V3

### DIFF
--- a/esp8266_deauther/ap.cpp
+++ b/esp8266_deauther/ap.cpp
@@ -154,7 +154,7 @@ namespace ap {
         debugln(ap_settings.pswd);
 
         debugF("Mode:      ");
-        debugln(ap_settings.pswd == '\0' ? "WPA2" : "Open");
+        debugln(*ap_settings.pswd == '\0' ? "Open" : "WPA2");
 
         debugF("Hidden:    ");
         debugln(strh::boolean(ap_settings.hidden));


### PR DESCRIPTION
- `ap.cpp` was unable to compile due to the comparison between a pointer (`ap_settings.pswd`) and an integer (nullbyte `\0`).
- Reporting of Open / WPA2 was reversed / incorrect