### PR TITLE
Update update_manuf.py

### DIFF
--- a/utils/vendor_list_updater/update_manuf.py
+++ b/utils/vendor_list_updater/update_manuf.py
@@ -9,7 +9,9 @@
 import argparse
 from urllib.request import urlopen
 
-WS_MANUF_FILE_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=manuf"
+# Old URL doesn't work anymore - WS_MANUF_FILE_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=manuf"
+# I've changed the URL to the new working URL which is actively kept up to date - Done by Ricardo Penders (soharddbwarez)
+WS_MANUF_FILE_URL = "https://gitlab.com/wireshark/wireshark/-/raw/master/manuf?p=wireshark.git;a=blob_plain;f=manuf"
 macs = []
 vendors = []
 tempVendors = []


### PR DESCRIPTION
Changed not working URL to the new Wireshark repository which is actively kept up to date

Signed-off-by: Ricardo <penders.ricardo@gmail.com>