### PR TITLE
Fixed problem with transition between menus

### DIFF
--- a/esp8266_deauther/DisplayUI.cpp
+++ b/esp8266_deauther/DisplayUI.cpp
@@ -312,7 +312,7 @@ void DisplayUI::setup() {
         addMenuNode(&stationMenu, [this]() {
             return str(D_AP) + stations.getAPStr(selectedID); // AP: someAP
         }, [this]() {
-            int apID = accesspoints.find(stations.getAP(selectedID));
+            int apID = stations.getAP(selectedID);
 
             if (apID >= 0) {
                 selectedID = apID;


### PR DESCRIPTION
I noticed that when I go from the station menu to the AP menu, the menu of another Ap is displayed. It was solved by changing one line of code