### PR TITLE
Clock-first deauther-second interface

### DIFF
--- a/esp8266_deauther/DisplayUI.cpp
+++ b/esp8266_deauther/DisplayUI.cpp
@@ -14,7 +14,7 @@ void DisplayUI::configInit() {
        make sure to have version 4 of the display library installed
        https://github.com/ThingPulse/esp8266-oled-ssd1306/releases/tag/4.0.0
      */
-    display.setFont(DejaVu_Sans_Mono_12);
+    setDefaultFont();
 
     display.setContrast(255);
 
@@ -445,13 +445,11 @@ void DisplayUI::setup() {
     createMenu(&clockMenu, &mainMenu, [this]() {
         addMenuNode(&clockMenu, D_CLOCK_DISPLAY, [this]() { // CLOCK
             mode = DISPLAY_MODE::CLOCK_DISPLAY;
-            display.setFont(ArialMT_Plain_24);
-            display.setTextAlignment(TEXT_ALIGN_CENTER);
+            setClockFont();
         });
         addMenuNode(&clockMenu, D_CLOCK_SET, [this]() { // CLOCK SET TIME
             mode = DISPLAY_MODE::CLOCK;
-            display.setFont(ArialMT_Plain_24);
-            display.setTextAlignment(TEXT_ALIGN_CENTER);
+            setClockFont();
         });
     });
 
@@ -512,6 +510,16 @@ void DisplayUI::off() {
     } else {
         prntln(D_ERROR_NOT_ENABLED);
     }
+}
+
+void DisplayUI::setDefaultFont() {
+    display.setFont(DejaVu_Sans_Mono_12);
+    display.setTextAlignment(TEXT_ALIGN_LEFT);
+}
+
+void DisplayUI::setClockFont() {
+    display.setFont(ArialMT_Plain_24);
+    display.setTextAlignment(TEXT_ALIGN_CENTER);
 }
 
 void DisplayUI::setupButtons() {
@@ -612,8 +620,7 @@ void DisplayUI::setupButtons() {
                 case DISPLAY_MODE::CLOCK:
                 case DISPLAY_MODE::CLOCK_DISPLAY:
                     mode = DISPLAY_MODE::MENU;
-                    display.setFont(DejaVu_Sans_Mono_12);
-                    display.setTextAlignment(TEXT_ALIGN_LEFT);
+                    setDefaultFont();
                     break;
             }
         }
@@ -651,8 +658,7 @@ void DisplayUI::setupButtons() {
 
                 case DISPLAY_MODE::CLOCK:
                     mode = DISPLAY_MODE::MENU;
-                    display.setFont(DejaVu_Sans_Mono_12);
-                    display.setTextAlignment(TEXT_ALIGN_LEFT);
+                    setDefaultFont();
                     break;
             }
         }

--- a/esp8266_deauther/DisplayUI.h
+++ b/esp8266_deauther/DisplayUI.h
@@ -132,6 +132,9 @@ class DisplayUI {
         void on();
         void off();
 
+        void setDefaultFont();
+        void setClockFont();
+
     private:
         int16_t selectedID    = 0; // i.e. access point ID to draw the apMenu
         uint8_t scrollCounter = 0; // for horizontal scrolling

--- a/esp8266_deauther/esp8266_deauther.ino
+++ b/esp8266_deauther/esp8266_deauther.ino
@@ -115,7 +115,7 @@ void setup() {
     if (settings::getDisplaySettings().enabled) {
         displayUI.setup();
         displayUI.setClockFont();
-        displayUI.mode = DISPLAY_MODE::CLOCK;
+        displayUI.mode = DISPLAY_MODE::CLOCK_DISPLAY;
     }
 
     // load everything else

--- a/esp8266_deauther/esp8266_deauther.ino
+++ b/esp8266_deauther/esp8266_deauther.ino
@@ -114,7 +114,8 @@ void setup() {
     // start display
     if (settings::getDisplaySettings().enabled) {
         displayUI.setup();
-        displayUI.mode = DISPLAY_MODE::INTRO;
+        displayUI.setClockFont();
+        displayUI.mode = DISPLAY_MODE::CLOCK;
     }
 
     // load everything else


### PR DESCRIPTION
I modified the firmware for the DSTIKE watch and other ESP8266-based devices so that they boot directly to the clock screen, which enhances their daily functionality. During this process, I also added two public member functions to the DisplayUI class to manage the switch between the default font and the clock font, following the DRY (Don't Repeat Yourself) principle.

This version of the firmware could be made available in a dedicated branch for users who prefer a clock-first, deauther-second interface.